### PR TITLE
added aquatint submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "aquatint"]
+	path = aquatint
+	url = git@github.com:alanmmckay/aquatint.git


### PR DESCRIPTION
Merging old commit which creates a space for the Aquatint webapp.

Likely used the following command:

`git submodule add https://github.com/alanmmckay/aquatint`, but am uncertain as I did not take explicit notes here.

